### PR TITLE
Planet: use a custom HTTP user agent

### DIFF
--- a/pelican_planet/planet.py
+++ b/pelican_planet/planet.py
@@ -48,7 +48,10 @@ class Planet:
         self.logger.info('Parsing "%s" feed from <%s> ...', name, url)
 
         try:
-            parsed = feedparser.parse(url)
+            parsed = feedparser.parse(
+                url_file_stream_or_string=url,
+                agent=self.get_user_agent(),
+            )
         except URLError as ex:
             # handle broken SSL certificates
             raise FeedError(f"Could not download {name}'s feed: {str(ex)}")
@@ -166,3 +169,7 @@ class Planet:
         # render some information when run in GitHub Actions
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
         print(f"::notice::Fetched {len(articles)} articles from {len(feeds)} feeds")
+
+    @staticmethod
+    def get_user_agent() -> str:
+        return f'pelican-planet +https://github.com/macbre/pelican-planet'

--- a/pelican_planet/planet.py
+++ b/pelican_planet/planet.py
@@ -172,4 +172,4 @@ class Planet:
 
     @staticmethod
     def get_user_agent() -> str:
-        return f'pelican-planet +https://github.com/macbre/pelican-planet'
+        return f"pelican-planet +https://github.com/macbre/pelican-planet"

--- a/pelican_planet/tests/test_planet.py
+++ b/pelican_planet/tests/test_planet.py
@@ -117,7 +117,7 @@ def test_get_no_feeds():
 def test_get_feeds_404(monkeypatch, datadir):
     from pelican_planet.planet import Planet
 
-    def mock_parse(url):
+    def mock_parse(**kwargs):
         return {"status": 404}
 
     monkeypatch.setattr(feedparser, "parse", mock_parse)
@@ -134,7 +134,7 @@ def test_get_feeds_404(monkeypatch, datadir):
 def test_get_feeds_500(monkeypatch, datadir):
     from pelican_planet.planet import Planet
 
-    def mock_parse(url):
+    def mock_parse(**kwargs):
         return {"status": 500}
 
     monkeypatch.setattr(feedparser, "parse", mock_parse)
@@ -151,7 +151,7 @@ def test_get_feeds_500(monkeypatch, datadir):
 def test_get_feeds_ssl_error(monkeypatch, datadir):
     from pelican_planet.planet import Planet
 
-    def mock_parse(url):
+    def mock_parse(**kwargs):
         return {
             "bozo": 1,
             "bozo_exception": CertificateError(


### PR DESCRIPTION
```
$ nc -l 0.0.0.0 8088
GET /karadoc.atom.xml HTTP/1.1
Host: localhost:8088
User-Agent: pelican-planet +https://github.com/macbre/pelican-planet
Accept-Encoding: gzip, deflate
Accept: application/atom+xml,application/rdf+xml,application/rss+xml,application/x-netcdf,application/xml;q=0.9,text/xml;q=0.2,*/*;q=0.1
A-Im: feed
Connection: close
```